### PR TITLE
[sc-72505] Remove unused workflow_call from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  workflow_call:
 
 jobs:
   ci:


### PR DESCRIPTION
## Summary
- Removes the unused `workflow_call` trigger from ci.yml
- This trigger allows workflow reuse but isn't used — the shared CI workflow lives in `.github` repo

[sc-72505](https://app.shortcut.com/sgnl/story/72505)