### PR TITLE
Update shared CI workflow to v1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   ci:
-    uses: sgnl-actions/.github/.github/workflows/ci.yml@1780126e2605c69733f54ff7271b0cb4c8acf326 # v1.1.0
+    uses: sgnl-actions/.github/.github/workflows/ci.yml@30e8bcb7c4c7543d249f6fde73eb8b38901899f2 # v1.2.0


### PR DESCRIPTION
## Summary
- Update shared CI workflow reference to v1.2.0 (`30e8bcb`)
- v1.2.0 adds `npm cache clean --force` and `--prefer-online` to the lock file sync check
- Fixes a bug where stale git dependency resolutions in `package-lock.json` were not detected

See: [sgnl-actions/.github#6](https://github.com/sgnl-actions/.github/pull/6), [sgnl-actions/.github#7](https://github.com/sgnl-actions/.github/pull/7)

## Test plan
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)